### PR TITLE
Add support for private keys

### DIFF
--- a/ansible_modules/cisco_file_transfer.py
+++ b/ansible_modules/cisco_file_transfer.py
@@ -17,6 +17,7 @@ def main():
             port=dict(default=22, required=False),
             username=dict(required=True),
             password=dict(required=True),
+            key_file=dict(required=False),
             source_file=dict(required=True),
             dest_file=dict(required=True),
             dest_file_system=dict(required=False, default='flash:'),
@@ -31,6 +32,7 @@ def main():
         'ip': module.params['host'],
         'username': module.params['username'],
         'password': module.params['password'],
+        'key_file': module.params['key_file'],
         'port': int(module.params['port']),
         'verbose': False,
     }


### PR DESCRIPTION
Added support to be able to pass in a private key file.  Modified cisco_file_transfer.py to support this feature.  I successfully transferred a file with this feature by connecting to a Cisco router using a private key as well as I made sure a username and password would still continue to work.

Let me know if there are any issues with my changes.
